### PR TITLE
fix gigablueemmc image build trio4k

### DIFF
--- a/conf/machine/include/gigablue-gbtrio4k.inc
+++ b/conf/machine/include/gigablue-gbtrio4k.inc
@@ -107,6 +107,7 @@ IMAGE_CMD_gigablueemmc_append = "\
     mkdir -p ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs3; \
     mkdir -p ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs4; \
     cp -a ${IMAGE_ROOTFS}/* ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs1/; \
+    dd if=/dev/zero of=${DEPLOY_DIR_IMAGE}/${MACHINE}-partitions/rootfs.ext4 seek=${IMAGE_ROOTFS_SIZE} count=60 bs=1024; \
     mkfs.ext4 -F -i 4096 ${DEPLOY_DIR_IMAGE}/${MACHINE}-partitions/rootfs.ext4 -d ${DEPLOY_DIR_IMAGE}/userdata; \
     cd ${IMAGE_ROOTFS}; \
     tar -cvf ${DEPLOY_DIR_IMAGE}/rootfs.tar -C ${IMAGE_ROOTFS} .; \


### PR DESCRIPTION
This commit fixes the following issue shown after build image for trio4k

| mke2fs 1.43.4 (31-Jan-2017)
| The file /home/martin/oe5/build/tmp/deploy/images/gbtrio4k/gbtrio4k-partitions/rootfs.ext4 does not exist and no size was specified.
| WARNING: exit code 1 from a shell command.
| ERROR: Function failed: do_image_gigablueemmc