### PR TITLE
gigablue-opengl: install real name symlink for linker

### DIFF
--- a/recipes-bsp/recipes-graphics/gigablue-opengl.inc
+++ b/recipes-bsp/recipes-graphics/gigablue-opengl.inc
@@ -28,6 +28,7 @@ do_install() {
     install -d ${D}${libdir}
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0755 ${S}/lib/libMali.so ${D}${libdir}
+    ln -sf libMali.so ${D}${libdir}/libmali.so
     ln -sf libMali.so ${D}${libdir}/libGLESv2.so.2.0
     ln -sf libGLESv2.so.2.0 ${D}${libdir}/libGLESv2.so.2
     ln -sf libGLESv2.so.2 ${D}${libdir}/libGLESv2.so


### PR DESCRIPTION
for gbtrio4k kodi build fails, cannot link -lmali.
Fix it adding a proper libmali.so symlink.

Note: the driver installs old EGL headers, needing a compatibility patch
in kodi.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>