### PR TITLE
gigablue-kodi: add new recipes for kodi support on gbquad4k and gbue4k

### DIFF
--- a/recipes-bsp/recipes-kodi/gigablue-kodi-gbquad4k.bb
+++ b/recipes-bsp/recipes-kodi/gigablue-kodi-gbquad4k.bb
@@ -1,0 +1,10 @@
+require gigablue-kodi.inc
+
+COMPATIBLE_MACHINE = "^(gbquad4k)$"
+
+PV = "1.0"
+
+GLPR = "20180904-r0"
+
+SRC_URI[md5sum] = "c9e208f1adf4da2afa2f924be9895f81"
+SRC_URI[sha256sum] = "8496405b70c0ad61e1f3c36abcd126678bfe0c4ece2c1fb24e7e035c141e5d30"

--- a/recipes-bsp/recipes-kodi/gigablue-kodi-gbue4k.bb
+++ b/recipes-bsp/recipes-kodi/gigablue-kodi-gbue4k.bb
@@ -1,0 +1,10 @@
+require gigablue-kodi.inc
+
+COMPATIBLE_MACHINE = "^(gbue4k)$"
+
+PV = "1.0"
+
+GLPR = "20180904-r0"
+
+SRC_URI[md5sum] = "c9e208f1adf4da2afa2f924be9895f81"
+SRC_URI[sha256sum] = "8496405b70c0ad61e1f3c36abcd126678bfe0c4ece2c1fb24e7e035c141e5d30"

--- a/recipes-bsp/recipes-kodi/gigablue-kodi.inc
+++ b/recipes-bsp/recipes-kodi/gigablue-kodi.inc
@@ -1,0 +1,22 @@
+DESCRIPTION = "Gigablue xbmc support"
+SECTION = "base"
+LICENSE = "CLOSED"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+SRC_URI = "http://source.mynonpublic.com/gigablue/v3ddriver/xbmc-support_gb7252_${GLPR}.tar.gz"
+
+S = "${WORKDIR}/xbmc-support"
+
+do_install(){
+    install -d ${D}${includedir}
+    install -d ${D}${libdir}
+    install -m 0644 ${S}/gles_init.h ${D}${includedir}
+    install -m 0644 ${S}/gles_init.a ${D}${libdir}/gles_init.a
+    ln -sf gles_init.a ${D}${libdir}/libgles_init.a
+}
+
+PACKAGES = "${PN}"
+FILES_${PN} = "${includedir} ${libdir}"
+
+INSANE_SKIP_${PN} = "staticdev"


### PR DESCRIPTION
ex xbmc-support tarball
as seen in OE-A

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>