### PR TITLE
gigablue-opengl-gbtrio4k: restrict it to COMPATIBLE_MACHINE

### DIFF
--- a/recipes-bsp/recipes-graphics/gigablue-opengl-gbtrio4k.bb
+++ b/recipes-bsp/recipes-graphics/gigablue-opengl-gbtrio4k.bb
@@ -4,3 +4,5 @@ SRC_URI[md5sum] = "faf96419cc542a5fe0df49fd2914a7ad"
 SRC_URI[sha256sum] = "7614f03c1db3641ea8793c28fcfdaa74cf45a31f89a7df14114b522fb5576d6e"
 
 require gigablue-opengl.inc
+
+COMPATIBLE_MACHINE = "^(gbtrio4k)$"


### PR DESCRIPTION
The driver otherwise slips in other builds as virtual/egl provider:

 gigablue-opengl-gbtrio4k PROVIDES virtual/egl but was skipped:
 PREFERRED_PROVIDER_virtual/libgles1 set to zgemma-v3ddriver-i55,
 not gigablue-opengl-gbtrio4k

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>