### PR TITLE
meta-gigablue: add GB-cortexa15 to MACHINE_FEATURES

### DIFF
--- a/conf/machine/gbquad4k.conf
+++ b/conf/machine/gbquad4k.conf
@@ -2,8 +2,8 @@
 #@NAME: Gigablue Quad 4k
 #@DESCRIPTION: Machine configuration for the Gigablue Quad 4k
 
-MACHINE_FEATURES += "colorlcd gigabluelcd gigabluelcd400 mmc ci omb blindscan-dvbs blindscan-dvbc transcoding dvb-c"
-OPENPLI_FEATURES += "ci"
+MACHINE_FEATURES += "colorlcd gigabluelcd gigabluelcd400 mmc ci omb blindscan-dvbs blindscan-dvbc transcoding dvb-c GB-cortexa15"
+OPENPLI_FEATURES += "ci kodi"
 
 CHIPSET = "bcm7252s"
 

--- a/conf/machine/gbtrio4k.conf
+++ b/conf/machine/gbtrio4k.conf
@@ -5,7 +5,7 @@
 EXTRA_OECONF_append_pn-enigma2 = "--with-lcddev=/dev/null --with-alphablendingacceleration=always --with-blitaccelerationthreshold=250  --with-fillaccelerationthreshold=190000"
 
 MACHINE_FEATURES += " textlcd 7segment blindscan dvb-c hisil mali transcoding emmc"
-OPENPLI_FEATURES += " qtplugins"
+OPENPLI_FEATURES += " qtplugins kodi"
 DISTRO_FEATURES_remove = "x11 wayland"
 
 CHIPSET = "Hi3798Mv200"

--- a/conf/machine/gbue4k.conf
+++ b/conf/machine/gbue4k.conf
@@ -2,8 +2,8 @@
 #@NAME: Gigablue UE 4k
 #@DESCRIPTION: Machine configuration for the Gigablue UE 4k
 
-MACHINE_FEATURES += "colorlcd gigabluelcd gigabluelcd220 mmc ci omb blindscan-dvbs blindscan-dvbc transcoding dvb-c"
-OPENPLI_FEATURES += "ci"
+MACHINE_FEATURES += "colorlcd gigabluelcd gigabluelcd220 mmc ci omb blindscan-dvbs blindscan-dvbc transcoding dvb-c GB-cortexa15"
+OPENPLI_FEATURES += "ci kodi"
 
 CHIPSET = "bcm7252s"
 

--- a/conf/machine/include/gigablue-gb7252.inc
+++ b/conf/machine/include/gigablue-gb7252.inc
@@ -14,6 +14,9 @@ PREFERRED_PROVIDER_virtual/libgles2 = "gb-v3ddriver-gb7252"
 
 PACKAGECONFIG_GL_pn-qtbase = " gles2 eglfs linuxfb"
 
+# xbmc/kodi support
+DEPENDS_append_pn-kodi = " gigablue-kodi-${MACHINE}"
+
 IMGDEPLOYDIR ?= "${DEPLOY_DIR_IMAGE}"
 
 IMAGE_CMD_tar_prepend = "\

--- a/conf/machine/include/gigablue-gbtrio4k.inc
+++ b/conf/machine/include/gigablue-gbtrio4k.inc
@@ -84,8 +84,6 @@ require conf/machine/include/tune-cortexa15.inc
 # Qt
 PACKAGECONFIG_GL_pn-qtbase = "gles2 eglfs linuxfb"
 PACKAGECONFIG_FB_pn-qtbase = " "
-# Kodi
-#EXTRA_OECONF_append_pn-kodi += " --with-gpu=mali --enable-player=hiplayer"
 
 MACHINE_EXTRA_RRECOMMENDS = " \
 	ffmpeg \


### PR DESCRIPTION
 -gbtrio4k uses mali so is not changed
 -this is necessary for the build of kodi > 18 on the supported devices
 -remove now unnecessary EXTRA_OECMAKE for kodi

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>